### PR TITLE
Rename callTools to handleToolCalls

### DIFF
--- a/examples/tools.roc
+++ b/examples/tools.roc
@@ -35,7 +35,7 @@ loop = \{ client, previousMessages } ->
         _ ->
             messages = Chat.appendUserMessage previousMessages query
             response = Http.send (Chat.buildHttpRequest client messages {}) |> Task.result!
-            updatedMessages = getMessagesFromResponse messages response |> Tools.callTools! client toolHandlerMap
+            updatedMessages = getMessagesFromResponse messages response |> Tools.handleToolCalls! client toolHandlerMap
             printLastMessage! updatedMessages
             Task.ok (Step { client, previousMessages: updatedMessages })
 
@@ -88,7 +88,7 @@ utcNow = \_args ->
         |> Task.ok
 
 ## tool for the toCdt function
-toCdtTool : Tools.Tool
+toCdtTool : Tool
 toCdtTool =
     utcTimeParam = {
         name: "utcTime",
@@ -114,7 +114,7 @@ toCdt = \args ->
         |> Task.ok
 
 ## tool for the toCst function
-toCstTool : Tools.Tool
+toCstTool : Tool
 toCstTool =
     utcTimeParam = {
         name: "utcTime",

--- a/package/Tools.roc
+++ b/package/Tools.roc
@@ -1,4 +1,4 @@
-module { sendHttpReq } -> [Tool, ToolCall, buildTool, callTools, dispatchToolCalls] 
+module { sendHttpReq } -> [Tool, ToolCall, buildTool, handleToolCalls, dispatchToolCalls] 
 
 import json.Option exposing [Option]
 import InternalTools
@@ -33,13 +33,13 @@ HttpHeader : {
 
 ## Using the given toolHandlerMap, check the last message for tool calls, call all
 ## the tools in the tool call list, send the results back to the model, and handle 
-## any additional tool calls that may have been generated. When no more tool calls
-## are present, return the updated list of messages.
+## any additional tool calls that may have been generated. If or when no more tool 
+## calls are present, return the updated list of messages.
 ## 
 ## The toolHandlerMap is a dictionary mapping tool function names to functions 
 ## that take the arguments as a JSON string, parse the json, and return the tool's response.
-callTools : List Message, Client, Dict Str (Str -> Task Str _) -> Task (List Message) _
-callTools = \messages, client, toolHandlerMap ->
+handleToolCalls : List Message, Client, Dict Str (Str -> Task Str _) -> Task (List Message) _
+handleToolCalls = \messages, client, toolHandlerMap ->
     when List.last messages is
         Ok { role, toolCalls: tcs } if role == "assistant" ->
             when Option.get tcs is

--- a/package/Tools.roc
+++ b/package/Tools.roc
@@ -48,7 +48,7 @@ handleToolCalls = \messages, client, toolHandlerMap ->
                     messagesWithTools = List.join [messages, toolMessages]
                     response = sendHttpReq (Chat.buildHttpRequest client messagesWithTools {}) |> Task.result!
                     messagesWithResponse = getMessagesFromResponse messagesWithTools response
-                    callTools messagesWithResponse client toolHandlerMap
+                    handleToolCalls messagesWithResponse client toolHandlerMap
 
                 None -> Task.ok messages
 


### PR DESCRIPTION
- callTools name was not adequately descriptive of the fact that it would not only call the tools, but send the tool result back to the model.