### PR TITLE
Bug fix in tools example

### DIFF
--- a/examples/tools.roc
+++ b/examples/tools.roc
@@ -127,7 +127,7 @@ toCstTool =
 ## Handler for the toCst tool
 toCst : Str -> Task Str _
 toCst = \args ->
-    utcTime =
+    { utcTime } =
         args
             |> Str.toUtf8
             |> Decode.fromBytes Json.utf8


### PR DESCRIPTION
Fixed bug causing `utcTime` argument to `toCst` tool handler to fail to decode.