### PR TITLE
Remove triggers for docs workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,13 +1,13 @@
 name: Generate docs
 
 on:
-  release:
-    types:
-      - published
+  # release:
+  #   types:
+  #     - published
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
 
 jobs:
   generate-docs:


### PR DESCRIPTION
`roc docs` currently hangs for this package, which causes CI/CD to fail. Removed triggers which cause docs generation to run automatically.