### PR TITLE
Add optional parameter to limit how long handleToolCalls can loop

### DIFF
--- a/examples/roc-agent.roc
+++ b/examples/roc-agent.roc
@@ -36,7 +36,7 @@ main =
         Stdout.write! "You: "
         messages = Chat.appendUserMessage previousMessages Stdin.line! {}
         response = Http.send (Chat.buildHttpRequest client messages {}) |> Task.result!
-        updatedMessages = Chat.updateMessageList response messages |> Tools.handleToolCalls! client toolHandlerMap
+        updatedMessages = Chat.updateMessageList response messages |> Tools.handleToolCalls! client toolHandlerMap { maxModelCalls: 10 }
         printLastMessage! updatedMessages
         Task.ok (Step { previousMessages: updatedMessages })
 


### PR DESCRIPTION
Previously, handleToolCalls would loop until the model stops making tool calls. Added an optional parameter to limit the number of times the model is called before the loop is stopped. 